### PR TITLE
Add Symfony 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 vendor
 coverage
+Tests/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ php:
   - 7.0
 
 before_script:
-  - pear install pear/PHP_CodeSniffer
   - composer install -n
-  - phpenv rehash
 
 script:
-  - phpunit -c Tests/
-  - phpcs --standard=PSR2 --extensions=php --ignore=vendor .
+  - vendor/bin/phpunit -c Tests/
+  - vendor/bin/phpcs --standard=PSR2 --extensions=php --ignore=vendor .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: php
 
+sudo: false
+
 php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
 
 before_script:
   - pear install pear/PHP_CodeSniffer

--- a/DependencyInjection/JbConfigKnpMenuExtension.php
+++ b/DependencyInjection/JbConfigKnpMenuExtension.php
@@ -40,7 +40,7 @@ class JbConfigKnpMenuExtension extends Extension
 
         foreach ($container->getParameter('kernel.bundles') as $bundle) {
             $reflection = new \ReflectionClass($bundle);
-            if (is_file($file = dirname($reflection->getFilename()) . '/Resources/config/navigation.yml')) {
+            if (is_file($file = dirname($reflection->getFileName()) . '/Resources/config/navigation.yml')) {
                 $configuredMenus = array_replace_recursive($configuredMenus, $this->parseFile($file));
                 $container->addResource(new FileResource($file));
             }

--- a/DependencyInjection/JbConfigKnpMenuExtension.php
+++ b/DependencyInjection/JbConfigKnpMenuExtension.php
@@ -78,7 +78,7 @@ class JbConfigKnpMenuExtension extends Extension
      */
     public function parseFile($file)
     {
-        $bundleConfig = Yaml::parse(realpath($file));
+        $bundleConfig = Yaml::parse(file_get_contents(realpath($file)));
 
         if (!is_array($bundleConfig)) {
             return array();

--- a/Provider/ConfigurationMenuProvider.php
+++ b/Provider/ConfigurationMenuProvider.php
@@ -17,6 +17,7 @@ use Knp\Menu\FactoryInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Jb\Bundle\ConfigKnpMenuBundle\Event\ConfigureMenuEvent;
 use Knp\Menu\Provider\MenuProviderInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -42,11 +43,11 @@ class ConfigurationMenuProvider implements MenuProviderInterface
     protected $dispatcher;
 
     /**
-     * Security Context
+     * Security Authorization Checker
      *
-     * @var \Symfony\Component\Security\Core\SecurityContextInterface
+     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
      */
-    protected $securityContext;
+    protected $authorizationChecker;
 
     /**
      * An array of menu configuration
@@ -60,29 +61,29 @@ class ConfigurationMenuProvider implements MenuProviderInterface
      *
      * @param \Knp\Menu\FactoryInterface $factory the knp menu factory
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher the event dispatcher
-     * @param \Symfony\Component\Security\Core\SecurityContextInterface $securityContext security is_granted check
+     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker security is_granted check
      * @param array $configuration An array of menu configuration
      */
     public function __construct(
         FactoryInterface $factory,
         EventDispatcherInterface $dispatcher,
-        SecurityContextInterface $securityContext,
+        AuthorizationCheckerInterface $authorizationChecker,
         $configuration = array()
     ) {
         $this->factory = $factory;
         $this->dispatcher = $dispatcher;
-        $this->securityContext = $securityContext;
+        $this->authorizationChecker = $authorizationChecker;
         $this->configuration = $configuration;
     }
 
     /**
-     * Set security context
+     * Set security authorization checker
      *
-     * @param \Symfony\Component\Security\Core\SecurityContextInterface $securityContext security
+     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker security
      */
-    public function setSecurityContext(SecurityContextInterface $securityContext)
+    public function setAuthorizationChecker(AuthorizationCheckerInterface $authorizationChecker)
     {
-        $this->securityContext = $securityContext;
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     /**
@@ -290,14 +291,9 @@ class ConfigurationMenuProvider implements MenuProviderInterface
             return true;
         }
 
-        // No token. No rights.
-        if (!$this->securityContext->getToken()) {
-            return false;
-        }
-
         // Check if one of the role is granted
         foreach ($configuration['roles'] as $role) {
-            if ($this->securityContext->isGranted($role)) {
+            if ($this->authorizationChecker->isGranted($role)) {
                 return true;
             }
         }

--- a/Provider/ConfigurationMenuProvider.php
+++ b/Provider/ConfigurationMenuProvider.php
@@ -13,12 +13,11 @@
  */
 namespace Jb\Bundle\ConfigKnpMenuBundle\Provider;
 
-use Knp\Menu\FactoryInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Jb\Bundle\ConfigKnpMenuBundle\Event\ConfigureMenuEvent;
+use Knp\Menu\FactoryInterface;
 use Knp\Menu\Provider\MenuProviderInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * ConfigurationMenuProvider
@@ -61,14 +60,15 @@ class ConfigurationMenuProvider implements MenuProviderInterface
      *
      * @param \Knp\Menu\FactoryInterface $factory the knp menu factory
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher the event dispatcher
-     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker security is_granted check
+     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker
+     *                                                                                     security is_granted checker
      * @param array $configuration An array of menu configuration
      */
     public function __construct(
         FactoryInterface $factory,
         EventDispatcherInterface $dispatcher,
         AuthorizationCheckerInterface $authorizationChecker,
-        $configuration = array()
+        array $configuration = array()
     ) {
         $this->factory = $factory;
         $this->dispatcher = $dispatcher;
@@ -79,7 +79,7 @@ class ConfigurationMenuProvider implements MenuProviderInterface
     /**
      * Set security authorization checker
      *
-     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker security
+     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker
      */
     public function setAuthorizationChecker(AuthorizationCheckerInterface $authorizationChecker)
     {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,8 +5,8 @@ services:
     jb_config.menu.provider:
         class: %jb_config.menu.provider.class%
         arguments:
-            - @knp_menu.factory
-            - @event_dispatcher
-            - @security.context
+            - '@knp_menu.factory'
+            - '@event_dispatcher'
+            - '@security.context'
         tags:
             - { name: knp_menu.provider }

--- a/Tests/Provider/ConfigurationMenuProviderTest.php
+++ b/Tests/Provider/ConfigurationMenuProviderTest.php
@@ -20,7 +20,7 @@ class ConfigurationMenuProviderTest extends \PHPUnit_Framework_TestCase
     protected $configurationProvider;
 
     /**
-     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject
      */
     protected $authorizationChecker;
 
@@ -36,7 +36,9 @@ class ConfigurationMenuProviderTest extends \PHPUnit_Framework_TestCase
             ->method('buildOptions')
             ->will($this->returnValue(array('uri' => '/my-page')));
 
-        $this->authorizationChecker = $this->getMock('Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface');
+        $this->authorizationChecker = $this->getMock(
+            'Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface'
+        );
 
         $menuFactory = new MenuFactory();
         $menuFactory->addExtension($routingExtension);

--- a/Tests/phpunit.xml.dist
+++ b/Tests/phpunit.xml.dist
@@ -17,8 +17,12 @@
         </testsuite>
     </testsuites>
     <filter>
-        <blacklist>
-            <directory>../vendor</directory>
-        </blacklist>
+        <whitelist>
+            <directory>../</directory>
+            <exclude>
+                <directory>../vendor</directory>
+                <directory>../Tests</directory>
+            </exclude>
+        </whitelist>
     </filter>
 </phpunit>

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "license": "MIT",
     "require": {
         "knplabs/knp-menu-bundle": "~2.0",
-        "symfony/event-dispatcher": "~2.1"
+        "symfony/event-dispatcher": "~2.1",
+        "symfony/yaml": "~2.1|~3.0"
     },
     "autoload": {
         "psr-0": { "Jb\\Bundle\\ConfigKnpMenuBundle": "" }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "knplabs/knp-menu-bundle": "~2.0",
-        "symfony/event-dispatcher": "~2.1",
+        "symfony/event-dispatcher": "~2.1|~3.0",
         "symfony/yaml": "~2.1|~3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,14 @@
         "symfony/event-dispatcher": "~2.1|~3.0",
         "symfony/yaml": "~2.1|~3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8|~5.0",
+        "squizlabs/php_codesniffer": "~2.5"
+    },
     "autoload": {
         "psr-4": { "Jb\\Bundle\\ConfigKnpMenuBundle\\": "" }
     },
     "autoload-dev": {
         "psr-4": {"Jb\\Bundle\\ConfigKnpMenuBundle\\Tests\\": "Tests/"}
-    },
-    "target-dir": "Jb/Bundle/ConfigKnpMenuBundle"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,10 @@
         "symfony/yaml": "~2.1|~3.0"
     },
     "autoload": {
-        "psr-0": { "Jb\\Bundle\\ConfigKnpMenuBundle": "" }
+        "psr-4": { "Jb\\Bundle\\ConfigKnpMenuBundle\\": "" }
+    },
+    "autoload-dev": {
+        "psr-4": {"Jb\\Bundle\\ConfigKnpMenuBundle\\Tests\\": "Tests/"}
     },
     "target-dir": "Jb/Bundle/ConfigKnpMenuBundle"
 }


### PR DESCRIPTION
This PR introduces support for Symfony 3:
* _AuthorizationCheckerInterface_ is used to check security permissions instead of deprecated _SecurityContext_
* Yaml fixes:
** Escape strings strating with @
** Pass file content to Yaml parser, not file path.
* Autoloading improvements:
** Use PSR-4 instead of PSR-0
** Provide autoloading for tests.
* Little _ConfigurationMenuProviderTest_ refactoring:
** Use appropriate assertions: assertCount, assertNull, assertFalse.
** Split isGranted test case into two different cases 

Also i would suggest to remove following methods of ConfigurationMenuProvider as they were used only in tests:
* _Jb\Bundle\ConfigKnpMenuBundle\Provider\ConfigurationMenuProvider::setSecurityContext_
* _Jb\Bundle\ConfigKnpMenuBundle\Provider\ConfigurationMenuProvider::setConfiguration_