### PR TITLE
quoted scalar value for making yaml file compilant to symfony 4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,7 @@ parameters:
 
 services:
     jb_config.menu.provider:
-        class: %jb_config.menu.provider.class%
+        class: '%jb_config.menu.provider.class%'
         arguments:
             - '@knp_menu.factory'
             - '@event_dispatcher'


### PR DESCRIPTION
I'm getting a deprecation notice in symfony 3.1 because the scalar value is not quoted. I just fixed that. 

![deprecation](https://cloud.githubusercontent.com/assets/1130714/18326982/7e38a0c6-7548-11e6-8054-9af559395de4.png)
