### PR TITLE
public getConfiguration

### DIFF
--- a/Provider/ConfigurationMenuProvider.php
+++ b/Provider/ConfigurationMenuProvider.php
@@ -97,6 +97,17 @@ class ConfigurationMenuProvider implements MenuProviderInterface
     }
 
     /**
+     * Return configuration of menus
+     *
+     * @return array
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+
+    /**
      * {@inheritDoc}
      */
     public function get($name, array $options = array())


### PR DESCRIPTION
Ability to get whole configuration from ConfigurationMenuProvider.

This allows to pull configuration from service, modify if needed and set back to provider (for example in specific controllers/actions).

Example:

```php
    /**
     * @Route("/sprint/edit/{id}", name="sprint_edit")
     */
    public function editSprintAction($id)
    {
        $menu = $this->get('jb_config.menu.provider')->getConfiguration();
        $menu['main']['tree']['sprint']['children']['sprints']['children']['tmp'] = [
            'label'           => 'Edit sprint',
            'route'           => 'sprint_skills_sprint_edit',
            'routeParameters' => [
                'id' => $id,
            ],
            'labelAttributes' => [
                'icon' => 'fa-pencil',
            ],
        ];
        $this->get('jb_config.menu.provider')->setConfiguration($menu);
```

I know that this is messy solution, but it's also easiest and fastest to implement.