### PR TITLE
Upgrade composer.json to Symfony 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
 
 before_script:
   - COMPOSER_MEMORY_LIMIT=-1 composer install -n

--- a/Config/Definition/Builder/MenuNodeDefinition.php
+++ b/Config/Definition/Builder/MenuNodeDefinition.php
@@ -14,6 +14,7 @@
 namespace Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeParentInterface;
 
 /**
  * Configuration definition for menu nodes
@@ -22,14 +23,10 @@ class MenuNodeDefinition extends ArrayNodeDefinition
 {
     /**
      * Make menu hierarchy
-     *
-     * @param  int $depth
-     *
-     * @return MenuNodeDefinition
      */
-    public function menuNodeHierarchy($depth = 10)
+    public function menuNodeHierarchy(int $depth = 10): NodeParentInterface
     {
-        if ($depth == 0) {
+        if ($depth === 0) {
             return $this;
         }
 

--- a/Config/Definition/Builder/MenuTreeBuilder.php
+++ b/Config/Definition/Builder/MenuTreeBuilder.php
@@ -31,6 +31,7 @@
 namespace Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder;
 
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeParentInterface;
 
 /**
  * MenuTreeBuilder
@@ -46,16 +47,16 @@ class MenuTreeBuilder extends NodeBuilder
     {
         parent::__construct();
 
-        $this->nodeMapping['menu'] = __NAMESPACE__ . '\\MenuNodeDefinition';
+        $this->nodeMapping['menu'] = MenuNodeDefinition::class;
     }
 
     /**
      * Creates a child menu node
      *
      * @param  string $name The name of the node
-     * @return MenuNodeDefinition The child node
+     * @return NodeParentInterface The child node
      */
-    public function menuNode($name)
+    public function menuNode(string $name): NodeParentInterface
     {
         return $this->node($name, 'menu');
     }

--- a/DependencyInjection/NavigationConfiguration.php
+++ b/DependencyInjection/NavigationConfiguration.php
@@ -34,7 +34,7 @@ class NavigationConfiguration implements ConfigurationInterface
      *
      * @param string $rootName the menu root name
      */
-    public function setMenuRootName($rootName)
+    public function setMenuRootName(string $rootName): void
     {
         $this->rootName = $rootName;
     }
@@ -42,7 +42,7 @@ class NavigationConfiguration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder($this->rootName, 'array', new MenuTreeBuilder());
 

--- a/Event/ConfigureMenuEvent.php
+++ b/Event/ConfigureMenuEvent.php
@@ -24,42 +24,24 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class ConfigureMenuEvent extends Event
 {
-    const CONFIGURE = 'jb_config.navigation.menu_configure';
+    public const CONFIGURE = 'jb_config.navigation.menu_configure';
 
-    /**
-     * @var \Knp\Menu\FactoryInterface
-     */
-    private $factory;
+    private FactoryInterface $factory;
 
-    /**
-     * @var \Knp\Menu\ItemInterface
-     */
-    private $menu;
+    private ItemInterface $menu;
 
-    /**
-     * Constructor
-     *
-     * @param \Knp\Menu\FactoryInterface $factory
-     * @param \Knp\Menu\ItemInterface $menu
-     */
     public function __construct(FactoryInterface $factory, ItemInterface $menu)
     {
         $this->factory = $factory;
         $this->menu = $menu;
     }
 
-    /**
-     * @return \Knp\Menu\FactoryInterface
-     */
-    public function getFactory()
+    public function getFactory(): FactoryInterface
     {
         return $this->factory;
     }
 
-    /**
-     * @return \Knp\Menu\ItemInterface
-     */
-    public function getMenu()
+    public function getMenu(): ItemInterface
     {
         return $this->menu;
     }

--- a/Tests/Config/Definition/Builder/MenuNodeDefinitionTest.php
+++ b/Tests/Config/Definition/Builder/MenuNodeDefinitionTest.php
@@ -31,21 +31,18 @@
 namespace Jb\Bundle\ConfigKnpMenuBundle\Tests\Unit\Config\Definition\Builder;
 
 use Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuNodeDefinition;
+use Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuTreeBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuNodeDefinition
  */
-class MenuNodeDefinitionTest extends \PHPUnit\Framework\TestCase
+class MenuNodeDefinitionTest extends TestCase
 {
-    /**
-     * @var \Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuTreeBuilder
-     */
-    protected $builder;
+    protected MenuTreeBuilder|MockObject $builder;
 
-    /**
-     * @var MenuNodeDefinition
-     */
-    protected $definition;
+    protected MenuNodeDefinition $definition;
 
     /**
      * Init Mock
@@ -53,8 +50,8 @@ class MenuNodeDefinitionTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->builder = $this
-            ->getMockBuilder('Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuTreeBuilder')
-            ->setMethods(
+            ->getMockBuilder(MenuTreeBuilder::class)
+            ->onlyMethods(
                 array(
                     'node',
                     'children',
@@ -74,13 +71,13 @@ class MenuNodeDefinitionTest extends \PHPUnit\Framework\TestCase
     /**
      * Test that if depth is 0, then the menu node definition is returned
      */
-    public function testMenuNodeHierarchyZeroDepth()
+    public function testMenuNodeHierarchyZeroDepth(): void
     {
         $this->builder->expects($this->never())
             ->method('node');
 
         $this->assertInstanceOf(
-            'Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuNodeDefinition',
+            MenuNodeDefinition::class,
             $this->definition->menuNodeHierarchy(0)
         );
     }
@@ -88,25 +85,25 @@ class MenuNodeDefinitionTest extends \PHPUnit\Framework\TestCase
     /**
      * Test the recursive calls
      */
-    public function testMenuNodeHierarchyNonZeroDepth()
+    public function testMenuNodeHierarchyNonZeroDepth(): void
     {
-        $this->builder->expects($this->any())
+        $this->builder
             ->method('node')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->any())
+        $this->builder
             ->method('children')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->any())
+        $this->builder
             ->method('scalarNode')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->any())
+        $this->builder
             ->method('end')
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->any())
+        $this->builder
             ->method('prototype')
             ->will($this->returnSelf());
 
@@ -120,10 +117,10 @@ class MenuNodeDefinitionTest extends \PHPUnit\Framework\TestCase
             ->with(9)
             ->will($this->returnSelf());
 
-        $this->builder->expects($this->any())
+        $this->builder
             ->method('defaultTrue')
             ->will($this->returnSelf());
 
-        $this->definition->menuNodeHierarchy(10);
+        $this->definition->menuNodeHierarchy();
     }
 }

--- a/Tests/Config/Definition/Builder/MenuTreeBuilderTest.php
+++ b/Tests/Config/Definition/Builder/MenuTreeBuilderTest.php
@@ -31,17 +31,16 @@
 namespace Jb\Bundle\ConfigKnpMenuBundle\Tests\Config\Definition\Builder;
 
 use Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuTreeBuilder;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuNodeDefinition;
 
 /**
  * Tests for Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuTreeBuilder
  */
-class MenuTreeBuilderTest extends \PHPUnit\Framework\TestCase
+class MenuTreeBuilderTest extends TestCase
 {
-    /**
-     * @var \Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuTreeBuilder
-     */
-    protected $builder;
+    protected MenuTreeBuilder $builder;
 
     /**
      * Init builder
@@ -55,7 +54,7 @@ class MenuTreeBuilderTest extends \PHPUnit\Framework\TestCase
      * Test constructor
      * Verify if the menu node has been registered
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $reflection = new ReflectionClass($this->builder);
         $property = $reflection->getProperty('nodeMapping');
@@ -64,7 +63,7 @@ class MenuTreeBuilderTest extends \PHPUnit\Framework\TestCase
 
         $this->assertArrayHasKey('menu', $nodeMapping);
         $this->assertEquals(
-            'Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuNodeDefinition',
+            MenuNodeDefinition::class,
             $nodeMapping['menu']
         );
     }
@@ -72,11 +71,11 @@ class MenuTreeBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * Test if builder return a menu node
      */
-    public function testMenuNode()
+    public function testMenuNode(): void
     {
         $nodeDefinition = $this->builder->menuNode('test');
         $this->assertInstanceOf(
-            'Jb\Bundle\ConfigKnpMenuBundle\Config\Definition\Builder\MenuNodeDefinition',
+            MenuNodeDefinition::class,
             $nodeDefinition
         );
         $this->assertEquals('test', $nodeDefinition->getNode()->getName());

--- a/Tests/DependencyInjection/JbConfigKnpMenuExtensionTest.php
+++ b/Tests/DependencyInjection/JbConfigKnpMenuExtensionTest.php
@@ -2,27 +2,30 @@
 
 namespace Jb\Bundle\PhumborBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Jb\Bundle\ConfigKnpMenuBundle\DependencyInjection\JbConfigKnpMenuExtension;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Jb\Bundle\ConfigKnpMenuBundle\Tests\DependencyInjection\Fixtures\Bundle1\JbTest1Bundle;
+use Jb\Bundle\ConfigKnpMenuBundle\Tests\DependencyInjection\Fixtures\Bundle2\JbTest2Bundle;
 
 /**
  * Test Extension
  *
  * @author Jonathan Bouzekri <jonathan.bouzekri@gmail.com>
  */
-class JbConfigKnpMenuExtensionTest extends \PHPUnit\Framework\TestCase
+class JbConfigKnpMenuExtensionTest extends TestCase
 {
     /**
      * Test loading data from file
      */
-    public function testLoading()
+    public function testLoading(): void
     {
         $menuConfiguration = self::loadConfiguration();
 
-        $this->assertEquals($menuConfiguration['main']['tree']['second_item']['label'], 'Second Item Label');
-        $this->assertEquals($menuConfiguration['main']['tree']['first_item']['label'], 'First Item Label');
-        $this->assertEquals(count($menuConfiguration['main']['tree']['second_item']['children']), 1);
+        $this->assertEquals('Second Item Label', $menuConfiguration['main']['tree']['second_item']['label']);
+        $this->assertEquals('First Item Label', $menuConfiguration['main']['tree']['first_item']['label']);
+        $this->assertCount(1, $menuConfiguration['main']['tree']['second_item']['children']);
     }
 
     public static function loadConfiguration()
@@ -39,20 +42,18 @@ class JbConfigKnpMenuExtensionTest extends \PHPUnit\Framework\TestCase
      *
      * @param array $data
      *
-     * @return \Symfony\Component\DependencyInjection\ContainerBuilder
+     * @return ContainerBuilder
      */
-    protected static function createContainer($data = array())
+    protected static function createContainer(array $data = array()): ContainerBuilder
     {
-        $container = new ContainerBuilder(new ParameterBag(array_merge(array(
+        return new ContainerBuilder(new ParameterBag(array_merge(array(
             'kernel.bundles'     => array(
                 'JbTest1Bundle' =>
-                    'Jb\\Bundle\\ConfigKnpMenuBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle1\\JbTest1Bundle',
+                    JbTest1Bundle::class,
                 'JbTest2Bundle' =>
-                    'Jb\\Bundle\\ConfigKnpMenuBundle\\Tests\\DependencyInjection\\Fixtures\\Bundle2\\JbTest2Bundle'
+                    JbTest2Bundle::class
             ),
             'kernel.root_dir' => 'app'
         ), $data)));
-
-        return $container;
     }
 }

--- a/Tests/DependencyInjection/NavigationConfigurationTest.php
+++ b/Tests/DependencyInjection/NavigationConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace Jb\Bundle\ConfigKnpMenuBundle\Tests\DependencyInjection;
 
 use Jb\Bundle\ConfigKnpMenuBundle\DependencyInjection\NavigationConfiguration;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 
@@ -11,10 +12,10 @@ use Symfony\Component\Config\Definition\Processor;
  *
  * @author Jonathan Bouzekri <jonathan.bouzekri@gmail.com>
  */
-class NavigationConfigurationTest extends \PHPUnit\Framework\TestCase
+class NavigationConfigurationTest extends TestCase
 {
     /**
-     * @var \Jb\Bundle\ConfigKnpMenuBundle\DependencyInjection\NavigationConfiguration
+     * @var NavigationConfiguration
      */
     protected $navigationConfiguration;
 
@@ -30,7 +31,7 @@ class NavigationConfigurationTest extends \PHPUnit\Framework\TestCase
     /**
      * Test the default configuration
      */
-    public function testDefaultConfig()
+    public function testDefaultConfig(): void
     {
         $processor = new Processor();
         $config = $processor->processConfiguration($this->navigationConfiguration, array());
@@ -48,10 +49,10 @@ class NavigationConfigurationTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public static function buildRandomMenuItem($number = 1)
+    public static function buildRandomMenuItem(int $number = 1): array
     {
         return array(
-            'uri' => 'http://www.google.fr',
+            'uri' => 'https://www.google.fr',
             'route' => 'test'.$number,
             'routeParameters' => array(
                 'test' => 'test'.$number
@@ -81,7 +82,7 @@ class NavigationConfigurationTest extends \PHPUnit\Framework\TestCase
     /**
      * Test full tree configuration
      */
-    public function testTransformationConfiguration()
+    public function testTransformationConfiguration(): void
     {
 
         $data = array('childrenAttributes' => array(), 'tree' => array('item1' => self::buildRandomMenuItem()));
@@ -96,7 +97,7 @@ class NavigationConfigurationTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getInvalidTypeData
      */
-    public function testInvalidData($data)
+    public function testInvalidData($data): void
     {
         $this->expectException(InvalidConfigurationException::class);
 
@@ -109,7 +110,7 @@ class NavigationConfigurationTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function getInvalidTypeData()
+    public function getInvalidTypeData(): array
     {
         return array(
             array( array('tree' => array('item1' => array('uri' => array()))) ),
@@ -133,7 +134,7 @@ class NavigationConfigurationTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    protected static function getBundleDefaultConfig()
+    protected static function getBundleDefaultConfig(): array
     {
         return array('childrenAttributes' => array(), 'tree' => array());
     }

--- a/Tests/Event/ConfigureMenuEventTest.php
+++ b/Tests/Event/ConfigureMenuEventTest.php
@@ -6,24 +6,27 @@
 namespace Jb\Bundle\ConfigKnpMenuBundle\Tests\Event;
 
 use Jb\Bundle\ConfigKnpMenuBundle\Event\ConfigureMenuEvent;
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for Jb\Bundle\ConfigKnpMenuBundle\Event\ConfigureMenuEvent
  */
-class ConfigureMenuEventTest extends \PHPUnit\Framework\TestCase
+class ConfigureMenuEventTest extends TestCase
 {
     /**
-     * @var \Jb\Bundle\ConfigKnpMenuBundle\Event\ConfigureMenuEvent
+     * @var ConfigureMenuEvent
      */
     protected $event;
 
     /**
-     * @var \Knp\Menu\FactoryInterface
+     * @var FactoryInterface
      */
     protected $factory;
 
     /**
-     * @var \Knp\Menu\ItemInterface
+     * @var ItemInterface
      */
     protected $menu;
 
@@ -32,8 +35,8 @@ class ConfigureMenuEventTest extends \PHPUnit\Framework\TestCase
      */
     public function setUp(): void
     {
-        $this->factory = $this->createMock('Knp\Menu\FactoryInterface');
-        $this->menu = $this->createMock('Knp\Menu\ItemInterface');
+        $this->factory = $this->createMock(FactoryInterface::class);
+        $this->menu = $this->createMock(ItemInterface::class);
 
         $this->event = new ConfigureMenuEvent($this->factory, $this->menu);
     }
@@ -41,7 +44,7 @@ class ConfigureMenuEventTest extends \PHPUnit\Framework\TestCase
     /**
      * test event getter
      */
-    public function testGetter()
+    public function testGetter(): void
     {
         $this->assertEquals($this->factory, $this->event->getFactory());
         $this->assertEquals($this->menu, $this->event->getMenu());

--- a/Tests/Provider/ConfigurationMenuProviderTest.php
+++ b/Tests/Provider/ConfigurationMenuProviderTest.php
@@ -9,19 +9,24 @@ use Jb\Bundle\ConfigKnpMenuBundle\Provider\ConfigurationMenuProvider;
 use Jb\Bundle\PhumborBundle\Tests\DependencyInjection\JbConfigKnpMenuExtensionTest;
 use Knp\Menu\MenuFactory;
 use Knp\Menu\Integration\Symfony\RoutingExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Knp\Menu\ItemInterface;
 
 /**
  * Tests for Jb\Bundle\ConfigKnpMenuBundle\Provider\ConfigurationMenuProvider
  */
-class ConfigurationMenuProviderTest extends \PHPUnit\Framework\TestCase
+class ConfigurationMenuProviderTest extends TestCase
 {
     /**
-     * @var \Jb\Bundle\ConfigKnpMenuBundle\Provider\ConfigurationMenuProvider
+     * @var ConfigurationMenuProvider
      */
     protected $configurationProvider;
 
     /**
-     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface
+     * @var AuthorizationCheckerInterface
      */
     protected $authorizationChecker;
 
@@ -30,19 +35,19 @@ class ConfigurationMenuProviderTest extends \PHPUnit\Framework\TestCase
      */
     protected function setUp(): void
     {
-        $urlGenerator = $this->createMock('Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface');
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator
           ->method('generate')
-          ->will($this->returnValue('/my-page'));
+          ->willReturn('/my-page');
 
         $this->authorizationChecker = $this->createMock(
-            'Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface'
+            AuthorizationCheckerInterface::class
         );
 
         $menuFactory = new MenuFactory();
         $menuFactory->addExtension(new RoutingExtension($urlGenerator));
 
-        $eventDispatcher = $this->createMock('Symfony\\Component\\EventDispatcher\\EventDispatcherInterface');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $configuration = JbConfigKnpMenuExtensionTest::loadConfiguration();
 
         $this->configurationProvider = new ConfigurationMenuProvider(
@@ -56,7 +61,7 @@ class ConfigurationMenuProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * test get
      */
-    public function testGet()
+    public function testGet(): void
     {
         $this->authorizationChecker
             ->method('isGranted')
@@ -125,8 +130,8 @@ class ConfigurationMenuProviderTest extends \PHPUnit\Framework\TestCase
 
         $position = 0;
         foreach ($menu->getChildren() as $key => $item) {
-            if ($key == 'first_item') {
-                $this->assertEquals(0, $position, 'First item postion');
+            if ($key === 'first_item') {
+                $this->assertEquals(0, $position, 'First item position');
             }
             $position++;
         }
@@ -157,7 +162,7 @@ class ConfigurationMenuProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * test get with multiple menu
      */
-    public function testMultipleMenus()
+    public function testMultipleMenus(): void
     {
         $this->authorizationChecker
             ->method('isGranted')
@@ -180,7 +185,7 @@ class ConfigurationMenuProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * test with roles
      */
-    public function testWithRolesNotGranted()
+    public function testWithRolesNotGranted(): void
     {
         $this->authorizationChecker
             ->method('isGranted')
@@ -197,7 +202,7 @@ class ConfigurationMenuProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * test with roles
      */
-    public function testWithRolesGranted()
+    public function testWithRolesGranted(): void
     {
         $this->authorizationChecker
             ->method('isGranted')
@@ -206,7 +211,7 @@ class ConfigurationMenuProviderTest extends \PHPUnit\Framework\TestCase
         $menu = $this->configurationProvider->get('menu_roles');
 
         $this->assertInstanceOf(
-            'Knp\\Menu\\ItemInterface',
+            ItemInterface::class,
             $menu->getChild('item2'),
             'authenticated and rights'
         );

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!is_file($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
-    throw new \LogicException('Could not find autoload.php in vendor/. Did you run "composer install --dev"?');
+    throw new LogicException('Could not find autoload.php in vendor/. Did you run "composer install --dev"?');
 }
 
 require $autoloadFile;

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,12 @@
     "license": "MIT",
     "require": {
         "knplabs/knp-menu-bundle": "~3.0",
-        "symfony/event-dispatcher": "^4.0|^5.0",
-        "symfony/yaml": "^4.0|^5.0",
-        "symfony/security-core": "^4.0|^5.0"
+        "symfony/event-dispatcher": "^4.0|^5.0|^6.0",
+        "symfony/yaml": "^4.0|^5.0|^6.0",
+        "symfony/security-core": "^4.0|^5.0|^6.0"
     },
     "require-dev": {
+        "roave/security-advisories": "dev-latest",
         "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.0"
     },


### PR DESCRIPTION
Upgrade composer.json to Symfony 6.0, fix tests, add missing return statements, fix invalid code

Issue: https://github.com/jbouzekri/ConfigKnpMenuBundle/issues/23