### PR TITLE
Add testcase for nested extra keys

### DIFF
--- a/Config/Definition/Builder/MenuNodeDefinition.php
+++ b/Config/Definition/Builder/MenuNodeDefinition.php
@@ -64,7 +64,7 @@ class MenuNodeDefinition extends ArrayNodeDefinition
                         ->end()
                     ->end()
                     ->arrayNode('extras')
-                        ->prototype('scalar')
+                        ->prototype('variable')
                         ->end()
                     ->end()
                     ->menuNode('children')->menuNodeHierarchy($depth - 1)

--- a/Tests/DependencyInjection/Fixtures/Bundle2/Resources/config/navigation.yml
+++ b/Tests/DependencyInjection/Fixtures/Bundle2/Resources/config/navigation.yml
@@ -27,6 +27,9 @@ main:
             extras:
               key1: value1
               key2: value2
+              routes:
+                  - pattern: /^foo/
+                  - pattern: /^bar/
         four_item:
             label: "Four Item Label"
             order: 40

--- a/Tests/Provider/ConfigurationMenuProviderTest.php
+++ b/Tests/Provider/ConfigurationMenuProviderTest.php
@@ -121,6 +121,8 @@ class ConfigurationMenuProviderTest extends TestCase
               'key1' => 'value1',
               'key2' => 'value2',
               'routes' => array(
+                array('pattern' => '/^foo/'),
+                array('pattern' => '/^bar/'),
                 array('route' => 'my_route', 'parameters' => array('test' => 'test1'))
               )
             ),


### PR DESCRIPTION
The [RouterVoter](https://github.com/KnpLabs/KnpMenu/blob/master/src/Knp/Menu/Matcher/Voter/RouteVoter.php#L38) requires a litte bit more complex structure in the extra keys, in order to calculate if an item is active or not. 

Example:
```yaml
account_tabs:
    tree:
        admin:
            label: Admin
            route: admin
            extras:
                routes:
                      - pattern: "/^admin/"
        profile:
            label: Profile
            route: profile
            extras:
                routes: 
                    - 'profile_update'
                    - 'profile_index'
                    - 'profile_change_password'
```